### PR TITLE
Try rendering with ggVennDiagram and jsonlite packages added to a docker image

### DIFF
--- a/anvilPoll2024MainAnalysis.Rmd
+++ b/anvilPoll2024MainAnalysis.Rmd
@@ -11,7 +11,7 @@ library(here)
 library(grid) #for Grobs
 library(scales)
 library(forcats)
-if (!require("ggVennDiagram")) install.packages("ggVennDiagram", repos = "http://cran.us.r-project.org")
+#if (!require("ggVennDiagram")) install.packages("ggVennDiagram", repos = "http://cran.us.r-project.org")
 library(ggVennDiagram)
 
 resultsTidy <- poll_results$df2024

--- a/anvilPoll2025MainAnalysis.Rmd
+++ b/anvilPoll2025MainAnalysis.Rmd
@@ -11,7 +11,7 @@ library(here)
 library(grid) #for Grobs
 library(scales)
 library(forcats)
-if (!require("ggVennDiagram")) install.packages("ggVennDiagram", repos = "http://cran.us.r-project.org")
+#if (!require("ggVennDiagram")) install.packages("ggVennDiagram", repos = "http://cran.us.r-project.org")
 library(ggVennDiagram)
 
 resultsTidy <- poll_results$df2025

--- a/config_automation.yml
+++ b/config_automation.yml
@@ -23,4 +23,4 @@ make-book-txt: TRUE
 
 # What docker image should be used for rendering?
 # The default is jhudsl/base_ottr:main
-rendering-docker-image: 'jhudsl/anvil-poll-2024:main'
+rendering-docker-image: 'jhudsl/ottr_anvil_poll:dev'

--- a/resources/render.R
+++ b/resources/render.R
@@ -1,4 +1,4 @@
-install.packages("jsonlite", repos = "https://cloud.r-project.org")
+#install.packages("jsonlite", repos = "https://cloud.r-project.org")
 
 library(optparse) # make_option OptionParser parse_args
 library(jsonlite) # fromJSON


### PR DESCRIPTION
Rather than installing the packages, trying to use an expanded docker image. The changes we merged to main this morning weren't incorporated in the rendered website. [failed with an installation file being corrupt](https://github.com/fhdsl/AnVIL_SOTA_Polls/actions/runs/16122733383) -- so I've added them to the docker image over in the ottrproject/ottr-docker repo, pushed it as a dev image to dockerhub (after a [successful manual build](https://github.com/ottrproject/ottr-docker/actions/runs/16127704657/job/45508470999)), and am trying it out over here

related: https://github.com/ottrproject/ottr-docker/pull/7